### PR TITLE
fix(ButtonToggleGroupValueAccessor): fix to use correct event name from the group element for current value state

### DIFF
--- a/projects/forge-angular/src/lib/button-toggle/button-toggle-group-value-accessor.directive.ts
+++ b/projects/forge-angular/src/lib/button-toggle/button-toggle-group-value-accessor.directive.ts
@@ -14,11 +14,11 @@ export const BUTTON_TOGGLE_GROUP_VALUE_ACCESSOR: StaticProvider = {
 })
 export class ButtonToggleGroupValueAccessor implements ControlValueAccessor {
   @HostListener('forge-button-toggle-group-change', ['$event'])
-  public buttonToggleSelect(event: CustomEvent) {
+  public buttonToggleGroupChange(event: CustomEvent) {
     this.change(event.detail);
   }
 
-  @HostListener('blur', ['$event'])
+  @HostListener('focusout', ['$event'])
   public blur(event: Event) {
     this.onTouched();
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N/A
- Docs have been added / updated: N/A
- Does this PR introduce a breaking change? Y (will break current usage, but it considered a bug)
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
The underlying event name has been updated to properly reference the group element to accurately reflect the current value of the component.

## Additional information
Fixes #9 
