### PR TITLE
fix(peer-dependencies): allow Angular 15

### DIFF
--- a/projects/forge-angular/package.json
+++ b/projects/forge-angular/package.json
@@ -6,8 +6,8 @@
   "author": "Tyler Technologies, Inc.",
   "license": "Apache-2.0",
   "peerDependencies": {
-    "@angular/common": ">=13.3.0 < 15.0.0",
-    "@angular/core": ">=13.3.0 < 15.0.0",
+    "@angular/common": ">=13.3.0 < 16.0.0",
+    "@angular/core": ">=13.3.0 < 16.0.0",
     "@tylertech/forge": "^2.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N
- Docs have been added / updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y (No open issues)

## Describe the new behavior?
The peer dependencies on the forge-angular library project was updated to allow use in Angular v15 project

## Additional information
I did quick tests after updating the test website to v15, and everything seemed to work.
