### PR TITLE
fix: update list-item proxy for latest forge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3555,9 +3555,9 @@
       }
     },
     "@tylertech/forge": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@tylertech/forge/-/forge-2.12.0.tgz",
-      "integrity": "sha512-3EibsTRx7EEdxoHQjlkyyn/LPBpAO+53D0XQo1wU6xTRK2GmXtkrtxTR4DmBenAkYxhKfN+7z/FcJLSTV5mC3g==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@tylertech/forge/-/forge-2.13.1.tgz",
+      "integrity": "sha512-KKHtQt8303hsvUAlaUXcGLtVuVckhyiMQBBHpPq3lT2J2UOeAaCbczGDQcFRQagFinr+GIdyvFT0aaVppZ1aVA==",
       "requires": {
         "@tylertech/forge-core": "^2.1.0",
         "@tylertech/tyler-icons": "^1.12.0",
@@ -7512,9 +7512,9 @@
       "dev": true
     },
     "http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "dev": true
     },
     "http-deceiver": {
@@ -12370,9 +12370,9 @@
       "dev": true
     },
     "ua-parser-js": {
-      "version": "0.7.31",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.31.tgz",
-      "integrity": "sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==",
+      "version": "0.7.33",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
+      "integrity": "sha512-s8ax/CeZdK9R/56Sui0WM6y9OFREJarMRHqLB2EwkovemBxNQ+Bqu8GAsUnVcXKgphb++ghr/B2BZx4mahujPw==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@angular/platform-browser": "~13.3.0",
     "@angular/platform-browser-dynamic": "~13.3.0",
     "@angular/router": "~13.3.0",
-    "@tylertech/forge": "^2.12.0",
+    "@tylertech/forge": "^2.13.1",
     "@tylertech/tyler-icons": "^1.12.0",
     "rxjs": "~7.5.0",
     "tslib": "^2.3.0",

--- a/projects/forge-angular/src/lib/list-item/list-item.component.ts
+++ b/projects/forge-angular/src/lib/list-item/list-item.component.ts
@@ -178,11 +178,6 @@ export class ListItemComponent {
 		return this.elementRef.nativeElement.wrap;
 	}
 
-
-	public initializedCallback(...args: Parameters<ListItemComponentCustomElement['initializedCallback']>): ReturnType<ListItemComponentCustomElement['initializedCallback']> {
-		return this.zone.runOutsideAngular(() => this.elementRef.nativeElement.initializedCallback(...args));
-	}
-
 	/** Sets focus to this list item. */
 	public focus(...args: Parameters<ListItemComponentCustomElement['focus']>): ReturnType<ListItemComponentCustomElement['focus']> {
 		return this.zone.runOutsideAngular(() => this.elementRef.nativeElement.focus(...args));


### PR DESCRIPTION
## PR Checklist

- Tests for the changes have been added: n/a
- Docs have been added / updated: n/a
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? n/a

## Describe the new behavior?
Regenerate proxies to pick up removed `initializedCallback` method from ListItemComponent
