### PR TITLE
fix(popup-service): detect changes to fix initial position

### DIFF
--- a/projects/forge-angular/src/lib/popup/popup.service.ts
+++ b/projects/forge-angular/src/lib/popup/popup.service.ts
@@ -78,6 +78,9 @@ export class PopupService {
       this._destroy(popupElement, dcRef);
       sub.unsubscribe();
     });
+    
+    // Force initial change detection so component size can affect initial positioning.
+    dcRef.componentRef.changeDetectorRef.detectChanges();
 
     // Appends the popup element to the DOM
     popupElement.open = true;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: n/a
- Docs have been added / updated: n/a
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? n/a

## Describe the new behavior?
Currently, the popup was getting positioned before initial change detection, and typically did not have the correct size, which could lead to it being positioned off-screen after it renders.  Attempting to manually call `popupRef.nativeElement.position()` afterwards would correct he position, but not without a flash of scrollbars and jumping content.  Invoking change detection is run before setting `open = true` ensures the popup is properly positioned initally.

## Additional information
Add any other context about the change here.
