### PR TITLE
fix(autocomplete-value-accessor): fix to allow for setting disabled state of the autocomplete `<input>` element via reactive form controls

### DIFF
--- a/projects/forge-angular/src/lib/autocomplete/autocomplete-value-accessor.directive.ts
+++ b/projects/forge-angular/src/lib/autocomplete/autocomplete-value-accessor.directive.ts
@@ -1,7 +1,8 @@
 import { Directive, Renderer2, ElementRef, forwardRef, HostListener } from '@angular/core';
 import { StaticProvider } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
-import { IOption } from '@tylertech/forge';
+import { IAutocompleteComponent, IOption } from '@tylertech/forge';
+import { deepQuerySelectorAll } from '@tylertech/forge-core';
 
 export const AUTOCOMPLETE_VALUE_ACCESSOR: StaticProvider = {
   provide: NG_VALUE_ACCESSOR,
@@ -27,7 +28,7 @@ export class AutocompleteValueAccessor implements ControlValueAccessor {
   public onChange = (_: any): void => {};
   public onTouched = (): void => {};
 
-  constructor(private _elementRef: ElementRef, private _renderer: Renderer2) {
+  constructor(private _elementRef: ElementRef<IAutocompleteComponent>, private _renderer: Renderer2) {
   }
 
   public writeValue(value: any): void {
@@ -43,7 +44,10 @@ export class AutocompleteValueAccessor implements ControlValueAccessor {
   }
 
   public setDisabledState(isDisabled: boolean): void {
-    this._renderer.setProperty(this._elementRef.nativeElement, 'disabled', isDisabled);
+    const inputEl = this._elementRef.nativeElement.querySelector('input') ?? deepQuerySelectorAll(this._elementRef.nativeElement, 'input')[0];
+    if (inputEl) {
+      this._renderer.setProperty(inputEl, 'disabled', isDisabled);
+    }
   }
 
   public change(value: any | any[] | IOption | IOption[]): void {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N
- Docs have been added / updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
When disabling reactive form controls attached to `<forge-autocomplete>` elements, the `<input>` will now reflect the disabled state properly.
