### PR TITLE
fix(autocomplete-value-accessor): fix to allow for setting disabled state of the autocomplete <input> element via reactive form controls

### DIFF
--- a/projects/forge-angular/src/lib/autocomplete/autocomplete-value-accessor.directive.ts
+++ b/projects/forge-angular/src/lib/autocomplete/autocomplete-value-accessor.directive.ts
@@ -1,7 +1,8 @@
 import { Directive, Renderer2, ElementRef, forwardRef, HostListener } from '@angular/core';
 import { StaticProvider } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
-import { IOption } from '@tylertech/forge';
+import { IAutocompleteComponent, IOption } from '@tylertech/forge';
+import { deepQuerySelectorAll } from '@tylertech/forge-core';
 
 export const AUTOCOMPLETE_VALUE_ACCESSOR: StaticProvider = {
   provide: NG_VALUE_ACCESSOR,
@@ -15,19 +16,19 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: StaticProvider = {
 })
 export class AutocompleteValueAccessor implements ControlValueAccessor {
   @HostListener('forge-autocomplete-change', ['$event'])
-  public autocompleteChange(event: CustomEvent) {
+  public autocompleteChange(event: CustomEvent): void {
     this.change(event.detail);
   }
 
-  @HostListener('focusout', ['$event'])
-  public blur(event: Event) {
+  @HostListener('focusout')
+  public blur(): void {
     this.onTouched();
   }
 
-  public onChange = (_: any) => {};
-  public onTouched = () => {};
+  public onChange = (_: any): void => {};
+  public onTouched = (): void => {};
 
-  constructor(private _elementRef: ElementRef, private _renderer: Renderer2) {
+  constructor(private _elementRef: ElementRef<IAutocompleteComponent>, private _renderer: Renderer2) {
   }
 
   public writeValue(value: any): void {
@@ -43,7 +44,10 @@ export class AutocompleteValueAccessor implements ControlValueAccessor {
   }
 
   public setDisabledState(isDisabled: boolean): void {
-    this._renderer.setProperty(this._elementRef.nativeElement, 'disabled', isDisabled);
+    const inputEl = this._elementRef.nativeElement.querySelector('input') ?? deepQuerySelectorAll(this._elementRef.nativeElement, 'input')[0];
+    if (inputEl) {
+      this._renderer.setProperty(inputEl, 'disabled', isDisabled);
+    }
   }
 
   public change(value: any | any[] | IOption | IOption[]): void {

--- a/src/app/views/components/popup/example-popup.component.ts
+++ b/src/app/views/components/popup/example-popup.component.ts
@@ -1,10 +1,7 @@
 import { Component } from '@angular/core';
-import { ForgeCardModule } from '@tylertech/forge-angular';
 
 @Component({
-    standalone: true,
     selector: 'example-popup',
-    template: `<forge-card>Example Popup</forge-card>`,
-    imports: [ForgeCardModule]
+    template: '<forge-card>Example Popup</forge-card>'
 })
 export class ExamplePopupComponent { }

--- a/src/app/views/components/popup/popup.module.ts
+++ b/src/app/views/components/popup/popup.module.ts
@@ -1,20 +1,22 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { ForgeButtonModule, ForgePopupModule, ForgePopupProxyModule, ForgeTextFieldModule } from '@tylertech/forge-angular';
+import { ForgeButtonModule, ForgeCardModule, ForgePopupModule, ForgePopupProxyModule, ForgeTextFieldModule } from '@tylertech/forge-angular';
 
 import { SharedModule } from '../../../shared/shared.module';
 import { PopupRoutingModule } from './popup-routing.module';
 import { PopupComponent } from './popup.component';
+import { ExamplePopupComponent } from './example-popup.component';
 
 @NgModule({
-  declarations: [PopupComponent],
+  declarations: [PopupComponent, ExamplePopupComponent],
   imports: [
     CommonModule,
     PopupRoutingModule,
     FormsModule,
     SharedModule,
     ForgeButtonModule,
+    ForgeCardModule,
     ForgePopupModule,
     ForgePopupProxyModule,
     ForgeTextFieldModule


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N
- Docs have been added / updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
When disabling reactive form controls attached to `<forge-autocomplete>` elements, the `<input>` will now reflect the disabled state properly.
