### PR TITLE
feat: enhance dialog service to manage open dialog refs

### DIFF
--- a/projects/forge-angular/src/lib/dialog/dialog.service.ts
+++ b/projects/forge-angular/src/lib/dialog/dialog.service.ts
@@ -9,6 +9,8 @@ import { IDynamicComponentRef } from '../core/dynamic-component/dynamic-componen
 import { Subject, take } from 'rxjs';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
+const MAX_NESTED_DIALOGS = 2;
+
 export interface IDialogOptions extends Omit<Partial<IDialogComponent>, 'attributes'> {
   dialogClass?: string;
   attributes?: Map<string, string>;
@@ -21,6 +23,7 @@ export interface IDialogOptions extends Omit<Partial<IDialogComponent>, 'attribu
   providedIn: 'root'
 })
 export class DialogService {
+  
   private _openDialogRefs: DialogRef[] = [];
   private _destroyRef: DestroyRef = inject(DestroyRef);
   constructor(private _dcs: DynamicComponentService, private _injector: Injector) {
@@ -114,7 +117,7 @@ export class DialogService {
 
   // While multiple dialogs is an anti-UX pattern, this is a minimal safeguard to protect against dirty dialogs
   private _closeAllDialogs(result: boolean, recursiveExecutionCount = 0): void {
-    if (recursiveExecutionCount > 2) {
+    if (recursiveExecutionCount > MAX_NESTED_DIALOGS) {
       throw new Error('Could not close all dialogs. Reason: Too many nested dialogs.');
     }
 

--- a/projects/forge-angular/src/lib/dialog/dialog.service.ts
+++ b/projects/forge-angular/src/lib/dialog/dialog.service.ts
@@ -109,7 +109,7 @@ export class DialogService implements OnDestroy {
   }
 
   /**
-   * Closes all dialogs. Will close up to 2 nested dialogs.
+   * Closes all dialogs.
    * @param result The result of closing the dialogs. Default is false.
    */
   public closeAllDialogs(result = false): void {

--- a/projects/forge-angular/src/lib/dialog/dialog.service.ts
+++ b/projects/forge-angular/src/lib/dialog/dialog.service.ts
@@ -31,12 +31,7 @@ export class DialogService implements OnDestroy {
    * @param component The component reference.
    * @param config The configuration to provide to the dynamic component as an injectable token.
    */
-  public show<T, K>(
-    component: Type<T>,
-    options?: IDialogOptions,
-    config?: DialogConfig,
-    moduleRef?: NgModuleRef<K>
-  ): DialogRef<T> {
+  public show<T, K>(component: Type<T> | ComponentFactory<T>, options?: IDialogOptions, config?: DialogConfig, moduleRef?: NgModuleRef<K>): DialogRef<T> {
     const dialogRef = this._showDialog(component, options, config, moduleRef);
     this._dialogRefs.push(dialogRef);
     dialogRef.afterClosed.pipe(take(1), takeUntil(this._unsubscribe$)).subscribe(() => this._removeDialogRef(dialogRef));
@@ -121,19 +116,8 @@ export class DialogService implements OnDestroy {
     this._closeAllDialogs(result);
   }
 
-  private _closeAllDialogs(result: boolean, recursiveExecutionCount = 0): void {
-    if (recursiveExecutionCount > 2) {
-      throw new Error('Could not close all dialogs. Reason: Too many nested dialogs.');
-    }
-
+  private _closeAllDialogs(result: boolean): void {
     this._dialogRefs.forEach((ref) => ref.close(result));
-    console.table(this._dialogRefs);
-
-    // This is here to close any dialogs that open as a result of other dialogs closing
-    // e.g. A dirty dialog opening when a dirty form dialog closes.
-    if (this._dialogRefs.length > 0) {
-      this._closeAllDialogs(result, ++recursiveExecutionCount);
-    }
   }
 
   private _removeDialogRef(ref: DialogRef): void {

--- a/projects/forge-angular/src/lib/dialog/dialog.service.ts
+++ b/projects/forge-angular/src/lib/dialog/dialog.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Injector } from '@angular/core';
+import { Injectable, Injector, OnDestroy } from '@angular/core';
 import { Type, ComponentFactory, NgModuleRef } from '@angular/core';
 import { IDialogComponent, DIALOG_CONSTANTS, defineDialogComponent } from '@tylertech/forge';
 import { DialogConfig } from './dialog-config';
@@ -6,6 +6,7 @@ import { DialogRef } from './dialog-ref';
 import { DialogInjector } from './dialog-injector';
 import { DynamicComponentService } from '../core/dynamic-component/dynamic-component.service';
 import { IDynamicComponentRef } from '../core/dynamic-component/dynamic-component.service';
+import { Subject, take, takeUntil } from 'rxjs';
 
 export interface IDialogOptions extends Omit<Partial<IDialogComponent>, 'attributes'> {
   dialogClass?: string;
@@ -18,7 +19,9 @@ export interface IDialogOptions extends Omit<Partial<IDialogComponent>, 'attribu
 @Injectable({
   providedIn: 'root'
 })
-export class DialogService {
+export class DialogService implements OnDestroy {
+  private _dialogRefs: DialogRef[] = [];
+  private _unsubscribe$ = new Subject();
   constructor(private _dcs: DynamicComponentService, private _injector: Injector) {
     defineDialogComponent();
   }
@@ -28,7 +31,19 @@ export class DialogService {
    * @param component The component reference.
    * @param config The configuration to provide to the dynamic component as an injectable token.
    */
-  public show<T, K>(component: Type<T> | ComponentFactory<T>, options?: IDialogOptions, config?: DialogConfig, moduleRef?: NgModuleRef<K>): DialogRef<T> {
+  public show<T, K>(
+    component: Type<T>,
+    options?: IDialogOptions,
+    config?: DialogConfig,
+    moduleRef?: NgModuleRef<K>
+  ): DialogRef<T> {
+    const dialogRef = this._showDialog(component, options, config, moduleRef);
+    this._dialogRefs.push(dialogRef);
+    dialogRef.afterClosed.pipe(take(1), takeUntil(this._unsubscribe$)).subscribe(() => this._removeDialogRef(dialogRef));
+    return dialogRef;
+  }
+
+  private _showDialog<T, K>(component: Type<T> | ComponentFactory<T>, options?: IDialogOptions, config?: DialogConfig, moduleRef?: NgModuleRef<K>): DialogRef<T> {
     // Contains tokens that will be provided to components through our custom dialog injector
     const map = new WeakMap();
 
@@ -91,5 +106,42 @@ export class DialogService {
   private _destroy<T>(dialogInstance: IDialogComponent, ref: IDynamicComponentRef<T>): void {
     dialogInstance.open = false;
     ref.destroy();
+  }
+
+  public ngOnDestroy(): void {
+    this._unsubscribe$.next(null);
+    this._unsubscribe$.complete();
+  }
+
+  /**
+   * Closes all dialogs. Will close up to 2 nested dialogs.
+   * @param result The result of closing the dialogs. Default is false.
+   */
+  public closeAllDialogs(result = false): void {
+    this._closeAllDialogs(result);
+  }
+
+  private _closeAllDialogs(result: boolean, recursiveExecutionCount = 0): void {
+    if (recursiveExecutionCount > 2) {
+      throw new Error('Could not close all dialogs. Reason: Too many nested dialogs.');
+    }
+
+    this._dialogRefs.forEach((ref) => ref.close(result));
+    console.table(this._dialogRefs);
+
+    // This is here to close any dialogs that open as a result of other dialogs closing
+    // e.g. A dirty dialog opening when a dirty form dialog closes.
+    if (this._dialogRefs.length > 0) {
+      this._closeAllDialogs(result, ++recursiveExecutionCount);
+    }
+  }
+
+  private _removeDialogRef(ref: DialogRef): void {
+    const index = this._dialogRefs.findIndex((dlgRef) => ref === dlgRef);
+    if (index < 0) {
+      return;
+    }
+
+    this._dialogRefs.splice(index, 1);
   }
 }

--- a/projects/forge-angular/src/lib/dialog/dialog.service.ts
+++ b/projects/forge-angular/src/lib/dialog/dialog.service.ts
@@ -117,6 +117,7 @@ export class DialogService implements OnDestroy {
     this._closeAllDialogs(result);
   }
 
+  // While multiple dialogs is an anti-UX pattern, this is a minimal safeguard to protect against dirty dialogs
   private _closeAllDialogs(result: boolean, recursiveExecutionCount = 0): void {
     if (recursiveExecutionCount > 2) {
       throw new Error('Could not close all dialogs. Reason: Too many nested dialogs.');

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -23,7 +23,7 @@ import { HomeComponent } from './views/home/home.component';
     AppComponent,
     HomeComponent,
     SidenavComponent,
-    HeaderComponent
+    HeaderComponent,
   ],
   imports: [BrowserModule, AppRoutingModule, HttpClientModule, DemoCardComponent, ForgeModule],
   providers: [],

--- a/src/app/components/example-content/example-content-routing.module.ts
+++ b/src/app/components/example-content/example-content-routing.module.ts
@@ -5,6 +5,7 @@ import { ExampleContentComponent } from './example-content.component';
 
 const routes: Routes = [
   { path: '', pathMatch: 'full', component: ExampleContentComponent },
+  { path: 'dialog-service', loadChildren: () => import('../../views/examples/dialog-service-example/dialog-service-example.module').then(m => m.DialogServiceExampleModule) },
   { path: 'expansion-panel', loadChildren: () => import('../../views/examples/expansion-panel-examples/expansion-panel-examples.module').then(m => m.ExpansionPanelExamplesModule) },
   { path: 'toolbar-example', loadChildren: () => import('../../views/examples/toolbar-example/toolbar-example.module').then(m => m.ToolbarExampleModule) },
   { path: 'two-column-grid', loadChildren: () => import('../../views/examples/two-column-grid/two-column-grid.module').then(m => m.TwoColumnGridModule) },

--- a/src/app/components/sidenav/sidenav.component.ts
+++ b/src/app/components/sidenav/sidenav.component.ts
@@ -85,11 +85,12 @@ export class SidenavComponent implements OnInit {
   ];
 
   public exampleMenuItems: IMenuItem[] = [
+    { label: 'Dialog Service', value: '/example/dialog-service' },
     { label: 'Expansion panel', value: '/example/expansion-panel' },
     { label: 'Reactive form', value: '/example/reactive-form' },
     { label: 'Table', value: '/example/table' },
     { label: 'Toolbar', value: '/example/toolbar-example' },
-    { label: 'Two column layout', value: '/example/two-column-grid' },
+    { label: 'Two column layout', value: '/example/two-column-grid' }
   ];
 
   constructor(private _router: Router, private _location: Location, private _cd: ChangeDetectorRef) {

--- a/src/app/views/components/dialog/dialog.component.html
+++ b/src/app/views/components/dialog/dialog.component.html
@@ -1,10 +1,8 @@
 <app-demo-card headerText="Dialog" #container>
   <div>
-
     <forge-button type="raised">
       <button (click)="showConfirmDialog()">Show confirm dialog</button>
     </forge-button>
-    
   </div>
 
   <br />

--- a/src/app/views/components/dialog/dialog.component.html
+++ b/src/app/views/components/dialog/dialog.component.html
@@ -1,7 +1,11 @@
 <app-demo-card headerText="Dialog" #container>
-  <forge-button type="raised">
-    <button (click)="showConfirmDialog()">Show confirm dialog</button>
-  </forge-button>
+  <div>
+
+    <forge-button type="raised">
+      <button (click)="showConfirmDialog()">Show confirm dialog</button>
+    </forge-button>
+    
+  </div>
 
   <br />
   <br />
@@ -61,4 +65,6 @@
       <label for="add-class" slot="label">Custom dialog class</label>
     </forge-text-field>
   </div>
+
+  
 </app-demo-card>

--- a/src/app/views/components/dialog/dialog.component.html
+++ b/src/app/views/components/dialog/dialog.component.html
@@ -63,6 +63,4 @@
       <label for="add-class" slot="label">Custom dialog class</label>
     </forge-text-field>
   </div>
-
-  
 </app-demo-card>

--- a/src/app/views/examples/dialog-service-example/count-down-dialog/count-down-dialog.component.html
+++ b/src/app/views/examples/dialog-service-example/count-down-dialog/count-down-dialog.component.html
@@ -1,0 +1,9 @@
+<forge-toolbar>
+  <h1 id="dialog-title" slot="start" class="forge-typography--title">Are you there?</h1>
+</forge-toolbar>
+<section>
+  <div class="forge-typography--body1">Looks like you've stepped away. We'll log you out in...</div>
+  <div class="seconds-container forge-typography--headline5">
+    <span id="seconds">{{counter$ | async}}</span><span>seconds</span>
+  </div>
+</section>

--- a/src/app/views/examples/dialog-service-example/count-down-dialog/count-down-dialog.component.scss
+++ b/src/app/views/examples/dialog-service-example/count-down-dialog/count-down-dialog.component.scss
@@ -1,0 +1,18 @@
+:host {
+  display: block;
+}
+
+.seconds-container {
+  margin-top: 8px;
+  display: flex;
+  justify-content: flex-end;
+  align-items: flex-end;
+}
+
+section {
+  padding: 16px;
+
+  & span:last-child {
+    margin-left: 8px;
+  }
+}

--- a/src/app/views/examples/dialog-service-example/count-down-dialog/count-down-dialog.component.ts
+++ b/src/app/views/examples/dialog-service-example/count-down-dialog/count-down-dialog.component.ts
@@ -1,0 +1,27 @@
+import { Component } from '@angular/core';
+import { DialogConfig } from '@tylertech/forge-angular';
+import { Observable } from 'rxjs';
+
+@Component({
+  selector: 'app-count-down-dialog',
+  templateUrl: './count-down-dialog.component.html',
+  styleUrls: ['./count-down-dialog.component.scss']
+})
+export class CountDownDialogComponent {
+  public counter$: Observable<number>;
+
+  constructor(public dialogConfig: DialogConfig) {
+    let localCounter = dialogConfig.data.counter;
+    
+    this.counter$ = new Observable(observer => {
+      const interval = setInterval(() => {
+        observer.next(localCounter);
+        if (localCounter === 0) {
+          clearInterval(interval);
+          observer.complete();
+        }
+        localCounter--;
+      }, 1000);
+    });
+  }
+}

--- a/src/app/views/examples/dialog-service-example/dialog-service-example-routing.module.ts
+++ b/src/app/views/examples/dialog-service-example/dialog-service-example-routing.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+import { DialogServiceExampleComponent } from './dialog-service-example.component';
+
+const routes: Routes = [
+  { path: '', component: DialogServiceExampleComponent }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class DialogServiceExampleRoutingModule {}

--- a/src/app/views/examples/dialog-service-example/dialog-service-example.component.html
+++ b/src/app/views/examples/dialog-service-example/dialog-service-example.component.html
@@ -19,16 +19,10 @@
   <forge-divider></forge-divider>
 
   <div style="display: flex; align-items: center; justify-content: space-around;">
-    <div  style="display: flex; flex-direction: column; align-items: start; justify-content: space-around;">
-      <forge-text-field>
-        <label for="input-id">Set timeout</label>
-        <input  [(ngModel)]="counter"  type="number" value="{{counter}}"/>
-      </forge-text-field>
       <forge-checkbox>
         <input type="checkbox" id="backdropClose" [(ngModel)]="result" />
         <label for="backdropClose">Close result: {{result}}</label>
       </forge-checkbox>
-    </div>
     <forge-button type="raised">
       <button (click)="showDialog()">Open dialog</button>
     </forge-button>

--- a/src/app/views/examples/dialog-service-example/dialog-service-example.component.html
+++ b/src/app/views/examples/dialog-service-example/dialog-service-example.component.html
@@ -1,0 +1,37 @@
+<app-demo-card headerText="Dialog Service Example" [fullWidth]="true">
+
+  <p class="forge-typography--subtitle1">
+    The Dialog service will keep track of dialogs that have been opened.  
+    When the dialog is closed, the service will destroy the reference.
+  </p>
+
+  <p class="forge-typography--subtitle1">
+    From the service, all dialogs can be closed by calling <code>closeAllDialogs()</code>.
+  </p>
+
+  <h2>Example Use:</h2>
+
+  <p class="forge-typography--subtitle1">
+    If your application includes a session idle monitoring service, the dialog service can be invoked to close all active dialogs when the idle service logs out the user. 
+    This ensures that there is no inadvertent access due to an open dialog when the session terminates.
+  </p>
+ 
+  <forge-divider></forge-divider>
+
+  <div style="display: flex; align-items: center; justify-content: space-around;">
+    <div  style="display: flex; flex-direction: column; align-items: start; justify-content: space-around;">
+      <forge-text-field>
+        <label for="input-id">Set timeout</label>
+        <input  [(ngModel)]="counter"  type="number" value="{{counter}}"/>
+      </forge-text-field>
+      <forge-checkbox>
+        <input type="checkbox" id="backdropClose" [(ngModel)]="result" />
+        <label for="backdropClose">Close result: {{result}}</label>
+      </forge-checkbox>
+    </div>
+    <forge-button type="raised">
+      <button (click)="showDialog()">Open dialog</button>
+    </forge-button>
+  </div>
+
+</app-demo-card>

--- a/src/app/views/examples/dialog-service-example/dialog-service-example.component.ts
+++ b/src/app/views/examples/dialog-service-example/dialog-service-example.component.ts
@@ -1,0 +1,65 @@
+import { Component } from '@angular/core';
+import { DialogService, IDialogOptions, ToastService } from '@tylertech/forge-angular';
+import { DialogComponent } from './dialog/dialog.component';
+import { FormControl } from '@angular/forms';
+import { take } from 'rxjs';
+
+@Component({
+  selector: 'app-dialog-service-example',
+  templateUrl: './dialog-service-example.component.html',
+  styleUrls: ['./dialog-service-example.component.scss']
+})
+export class DialogServiceExampleComponent {
+  public counter = 3;
+  public result = false;
+
+
+  constructor(
+    private _dialogService: DialogService,
+    private _toastService: ToastService
+    ) {}
+
+  public async showDialog(): Promise<void> {
+    let localCounter = this.counter;
+
+    const dialogOptions: IDialogOptions = {
+      backdropClose: false,
+      escapeClose: false,
+      // fullscreen: this.fullscreen,
+      moveable: true,
+      attributes: new Map([
+        ['aria-labelledby', 'dialog-title'],
+        ['aria-describedby', 'dialog-desc']
+      ]),
+      closeCallback: () => console.log('closeCallback')
+    };
+
+    const dialogConfig = {
+      data: {
+        counter: 3
+      }
+    };
+
+    const dialogRef = this._dialogService.show(
+      DialogComponent,
+      dialogOptions,
+      dialogConfig
+    );
+    console.log('Native Forge dialog instance', dialogRef.nativeElement);
+    console.log('[DialogRef] Angular componentInstance', dialogRef.componentInstance);
+
+    dialogRef.afterClosed.pipe(take(1)).subscribe(result => {
+      this._toastService.show(`Dialog closed with result: ${result}`);
+    });
+
+    const interval = setInterval(() => {
+      localCounter--;
+      if (localCounter === 0) {
+        clearInterval(interval);
+        console.log('closing all dialog');
+        this._dialogService.closeAllDialogs(this.result);
+      }
+    }, 1000);
+
+  }
+}

--- a/src/app/views/examples/dialog-service-example/dialog-service-example.component.ts
+++ b/src/app/views/examples/dialog-service-example/dialog-service-example.component.ts
@@ -54,7 +54,7 @@ export class DialogServiceExampleComponent {
 
     const interval = setInterval(() => {
       localCounter--;
-      if (localCounter === 0) {
+      if (localCounter < 0) {
         clearInterval(interval);
         console.log('closing all dialog');
         this._dialogService.closeAllDialogs(this.result);

--- a/src/app/views/examples/dialog-service-example/dialog-service-example.component.ts
+++ b/src/app/views/examples/dialog-service-example/dialog-service-example.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { DialogService, IDialogOptions, ToastService } from '@tylertech/forge-angular';
 import { DialogComponent } from './dialog/dialog.component';
 import { take } from 'rxjs';
+import { CountDownDialogComponent } from './count-down-dialog/count-down-dialog.component';
 
 @Component({
   selector: 'app-dialog-service-example',
@@ -9,7 +10,6 @@ import { take } from 'rxjs';
   styleUrls: ['./dialog-service-example.component.scss']
 })
 export class DialogServiceExampleComponent {
-  public counter = 3;
   public result = false;
 
 
@@ -19,8 +19,14 @@ export class DialogServiceExampleComponent {
     ) {}
 
   public async showDialog(): Promise<void> {
-    let localCounter = this.counter;
+    this._dialogService.show(DialogComponent);
 
+    setTimeout(() => {
+      this._openCountDownDialog();
+    }, 2000);
+  }
+
+  private _openCountDownDialog(): void {
     const dialogOptions: IDialogOptions = {
       backdropClose: false,
       escapeClose: false,
@@ -30,25 +36,26 @@ export class DialogServiceExampleComponent {
       ]),
       closeCallback: () => console.log('closeCallback')
     };
-
+    
     const dialogConfig = {
       data: {
-        counter: 3
+        counter: 5
       }
     };
-
-    const dialogRef = this._dialogService.show(
-      DialogComponent,
+    
+    const countDownDialogRef = this._dialogService.show(
+      CountDownDialogComponent,
       dialogOptions,
       dialogConfig
-    );
-    console.log('Native Forge dialog instance', dialogRef.nativeElement);
-    console.log('[DialogRef] Angular componentInstance', dialogRef.componentInstance);
+      );
+    console.log('Native Forge dialog instance', countDownDialogRef.nativeElement);
+    console.log('[DialogRef] Angular componentInstance', countDownDialogRef.componentInstance);
 
-    dialogRef.afterClosed.pipe(take(1)).subscribe(result => {
+    countDownDialogRef.afterClosed.pipe(take(1)).subscribe(result => {
       this._toastService.show(`Dialog closed with result: ${result}`);
     });
-
+    
+    let localCounter = 5;
     const interval = setInterval(() => {
       localCounter--;
       if (localCounter < 0) {
@@ -57,6 +64,6 @@ export class DialogServiceExampleComponent {
         this._dialogService.closeAllDialogs(this.result);
       }
     }, 1000);
-
   }
 }
+

--- a/src/app/views/examples/dialog-service-example/dialog-service-example.component.ts
+++ b/src/app/views/examples/dialog-service-example/dialog-service-example.component.ts
@@ -1,7 +1,6 @@
 import { Component } from '@angular/core';
 import { DialogService, IDialogOptions, ToastService } from '@tylertech/forge-angular';
 import { DialogComponent } from './dialog/dialog.component';
-import { FormControl } from '@angular/forms';
 import { take } from 'rxjs';
 
 @Component({
@@ -25,8 +24,6 @@ export class DialogServiceExampleComponent {
     const dialogOptions: IDialogOptions = {
       backdropClose: false,
       escapeClose: false,
-      // fullscreen: this.fullscreen,
-      moveable: true,
       attributes: new Map([
         ['aria-labelledby', 'dialog-title'],
         ['aria-describedby', 'dialog-desc']

--- a/src/app/views/examples/dialog-service-example/dialog-service-example.module.ts
+++ b/src/app/views/examples/dialog-service-example/dialog-service-example.module.ts
@@ -1,0 +1,23 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { DialogServiceExampleComponent } from './dialog-service-example.component';
+import { DemoCardComponent } from 'src/app/shared/components/demo-card/demo-card.component';
+import { DialogServiceExampleRoutingModule } from './dialog-service-example-routing.module';
+import { ForgeButtonModule, ForgeCheckboxModule, ForgeDividerModule, ForgeTextFieldModule} from '@tylertech/forge-angular';
+import { DialogComponent } from './dialog/dialog.component';
+import { FormsModule } from '@angular/forms';
+
+@NgModule({
+  declarations: [DialogServiceExampleComponent, DialogComponent],
+  imports: [
+    CommonModule,
+    FormsModule,
+    DialogServiceExampleRoutingModule,
+    DemoCardComponent,
+    ForgeButtonModule,
+    ForgeTextFieldModule,
+    ForgeDividerModule,
+    ForgeCheckboxModule
+  ]
+})
+export class DialogServiceExampleModule {}

--- a/src/app/views/examples/dialog-service-example/dialog-service-example.module.ts
+++ b/src/app/views/examples/dialog-service-example/dialog-service-example.module.ts
@@ -3,12 +3,13 @@ import { CommonModule } from '@angular/common';
 import { DialogServiceExampleComponent } from './dialog-service-example.component';
 import { DemoCardComponent } from 'src/app/shared/components/demo-card/demo-card.component';
 import { DialogServiceExampleRoutingModule } from './dialog-service-example-routing.module';
-import { ForgeButtonModule, ForgeCheckboxModule, ForgeDividerModule, ForgeTextFieldModule} from '@tylertech/forge-angular';
+import { ForgeButtonModule, ForgeCheckboxModule, ForgeDividerModule, ForgeTextFieldModule, ForgeToolbarModule} from '@tylertech/forge-angular';
 import { DialogComponent } from './dialog/dialog.component';
 import { FormsModule } from '@angular/forms';
+import { CountDownDialogComponent } from './count-down-dialog/count-down-dialog.component';
 
 @NgModule({
-  declarations: [DialogServiceExampleComponent, DialogComponent],
+  declarations: [DialogServiceExampleComponent, DialogComponent, CountDownDialogComponent],
   imports: [
     CommonModule,
     FormsModule,
@@ -17,7 +18,8 @@ import { FormsModule } from '@angular/forms';
     ForgeButtonModule,
     ForgeTextFieldModule,
     ForgeDividerModule,
-    ForgeCheckboxModule
+    ForgeCheckboxModule,
+    ForgeToolbarModule
   ]
 })
 export class DialogServiceExampleModule {}

--- a/src/app/views/examples/dialog-service-example/dialog/dialog.component.html
+++ b/src/app/views/examples/dialog-service-example/dialog/dialog.component.html
@@ -1,5 +1,5 @@
 <div class="app-dialog" >
-  <h2 id="dialog-title" forge-dialog-move-target>Open dialog</h2>
-  <p id="dialog-desc">Dialog will be closed by the service in {{counter$ | async}}</p>
+  <h2 forge-dialog-move-target>Open dialog</h2>
+  <p>Dialog will be closed by the service in {{counter$ | async}}</p>
 </div>
 

--- a/src/app/views/examples/dialog-service-example/dialog/dialog.component.html
+++ b/src/app/views/examples/dialog-service-example/dialog/dialog.component.html
@@ -1,5 +1,7 @@
-<div class="app-dialog" >
-  <h2 forge-dialog-move-target>Open dialog</h2>
-  <p>Dialog will be closed by the service in {{counter$ | async}}</p>
-</div>
+<forge-toolbar>
+  <h1 id="dialog-title" slot="start" class="forge-typography--title">Example dialog</h1>
+</forge-toolbar>
+<section>
+  <div class="forge-typography--body1">This is an example dialog that will be closed by the dialog service.</div>
+</section>
 

--- a/src/app/views/examples/dialog-service-example/dialog/dialog.component.html
+++ b/src/app/views/examples/dialog-service-example/dialog/dialog.component.html
@@ -1,0 +1,7 @@
+<div class="app-dialog" >
+  <h2 id="dialog-title" forge-dialog-move-target>Open dialog</h2>
+  <p id="dialog-desc">Dialog will be closed by the service in {{counter$ | async}}</p>
+  <div style="display: flex; justify-content: flex-end;">
+  </div>
+</div>
+

--- a/src/app/views/examples/dialog-service-example/dialog/dialog.component.html
+++ b/src/app/views/examples/dialog-service-example/dialog/dialog.component.html
@@ -1,7 +1,5 @@
 <div class="app-dialog" >
   <h2 id="dialog-title" forge-dialog-move-target>Open dialog</h2>
   <p id="dialog-desc">Dialog will be closed by the service in {{counter$ | async}}</p>
-  <div style="display: flex; justify-content: flex-end;">
-  </div>
 </div>
 

--- a/src/app/views/examples/dialog-service-example/dialog/dialog.component.scss
+++ b/src/app/views/examples/dialog-service-example/dialog/dialog.component.scss
@@ -1,5 +1,7 @@
-.app-dialog {
+:host {
   padding: 16px;
+  width: 80dvw;
+  height: 50dvh;
 
   h2 {
     margin-top: 0;

--- a/src/app/views/examples/dialog-service-example/dialog/dialog.component.scss
+++ b/src/app/views/examples/dialog-service-example/dialog/dialog.component.scss
@@ -1,0 +1,7 @@
+.app-dialog {
+  padding: 16px;
+
+  h2 {
+    margin-top: 0;
+  }
+}

--- a/src/app/views/examples/dialog-service-example/dialog/dialog.component.ts
+++ b/src/app/views/examples/dialog-service-example/dialog/dialog.component.ts
@@ -8,20 +8,19 @@ import { Observable, of } from 'rxjs';
   styleUrls: ['./dialog.component.scss']
 })
 export class DialogComponent {
-  private counter: number;
   public counter$: Observable<number>;
 
   constructor(public dialogConfig: DialogConfig) {
-    this.counter = dialogConfig.data.counter;
+    let localCounter = dialogConfig.data.counter;
     
     this.counter$ = new Observable(observer => {
       const interval = setInterval(() => {
-        observer.next(this.counter);
-        if (this.counter === 0) {
+        observer.next(localCounter);
+        if (localCounter === 0) {
           clearInterval(interval);
           observer.complete();
         }
-        this.counter--;
+        localCounter--;
       }, 1000);
     });
   }

--- a/src/app/views/examples/dialog-service-example/dialog/dialog.component.ts
+++ b/src/app/views/examples/dialog-service-example/dialog/dialog.component.ts
@@ -1,0 +1,28 @@
+import { Component } from '@angular/core';
+import { DialogConfig } from '@tylertech/forge-angular';
+import { Observable, of } from 'rxjs';
+
+@Component({
+  selector: 'app-dialog',
+  templateUrl: './dialog.component.html',
+  styleUrls: ['./dialog.component.scss']
+})
+export class DialogComponent {
+  private counter: number;
+  public counter$: Observable<number>;
+
+  constructor(public dialogConfig: DialogConfig) {
+    this.counter = dialogConfig.data.counter;
+    
+    this.counter$ = new Observable(observer => {
+      const interval = setInterval(() => {
+        observer.next(this.counter);
+        if (this.counter === 0) {
+          clearInterval(interval);
+          observer.complete();
+        }
+        this.counter--;
+      }, 1000);
+    });
+  }
+}

--- a/src/app/views/examples/dialog-service-example/dialog/dialog.component.ts
+++ b/src/app/views/examples/dialog-service-example/dialog/dialog.component.ts
@@ -1,27 +1,8 @@
 import { Component } from '@angular/core';
-import { DialogConfig } from '@tylertech/forge-angular';
-import { Observable, of } from 'rxjs';
 
 @Component({
   selector: 'app-dialog',
   templateUrl: './dialog.component.html',
   styleUrls: ['./dialog.component.scss']
 })
-export class DialogComponent {
-  public counter$: Observable<number>;
-
-  constructor(public dialogConfig: DialogConfig) {
-    let localCounter = dialogConfig.data.counter;
-    
-    this.counter$ = new Observable(observer => {
-      const interval = setInterval(() => {
-        observer.next(localCounter);
-        if (localCounter === 0) {
-          clearInterval(interval);
-          observer.complete();
-        }
-        localCounter--;
-      }, 1000);
-    });
-  }
-}
+export class DialogComponent {}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: [Y/N]
- Docs have been added / updated: [Y/N]
- Does this PR introduce a breaking change? [Y/N]  N
- I have linked any related GitHub issues to be closed when this PR is merged? [Y/N]  Y
 This would close [#45](https://github.com/tyler-technologies-oss/forge-angular/issues/45)

## Describe the new behavior?
Enhances the dialog service to manage open dialogs and give the ability to close all open dialogs.  Similar to the `MatDialogModule` in [Angular Material](https://v5.material.angular.io/components/dialog/api)

- Would give the dialog service the ability to manage open dialog refs and give the ability to close all dialogs currently managed.
- When `service.show()` is called, the dialog ref is added to an array
- Removal of dialog ref added to the dialog close subscription

## Describe any alternatives you've considered
A viable alternative to is to create an internal service with the suggested implementation that extends on the current dialog service and use that instead.

## Additional information
A specific use case for this feature: This functionality is derived from a user session termination with the tid-session manager.  In an app, when the session is terminated, if there is an open dialog, the dialog persists on top of the session timeout page and the user still has the ability to navigate the dialog given its a single or stepper.  The purposed enhanced functionality would allow the session manager to


