### PR TITLE
fix(BottomSheetService): fixed a bug where the value provided to `DialogRef.close()` was not being emitted from the `afterClosed` observable

### DIFF
--- a/projects/forge-angular/src/lib/bottom-sheet/bottom-sheet-ref.ts
+++ b/projects/forge-angular/src/lib/bottom-sheet/bottom-sheet-ref.ts
@@ -1,6 +1,6 @@
 import { ElementRef } from '@angular/core';
 import { AsyncSubject, Observable, Subject } from 'rxjs';
-import { BOTTOM_SHEET_CONSTANTS, IBottomSheetComponent } from '@tylertech/forge';
+import { IBottomSheetComponent } from '@tylertech/forge';
 
 export class BottomSheetRef<TComponent = any, TResult = any> {
   private readonly _elementRef: ElementRef<IBottomSheetComponent>;

--- a/projects/forge-angular/src/lib/bottom-sheet/bottom-sheet.service.ts
+++ b/projects/forge-angular/src/lib/bottom-sheet/bottom-sheet.service.ts
@@ -67,16 +67,14 @@ export class BottomSheetService {
 
       const element = (componentRef.hostView as EmbeddedViewRef<any>).rootNodes[0] as HTMLElement;
       bottomSheetElement.appendChild(element);
-
-      const sub = bottomSheetRef.afterClosed.subscribe(() => {
-        componentRef.destroy();
-        sub.unsubscribe();
-      });
   
       bottomSheetElement.addEventListener('forge-bottom-sheet-close', () => {
-        bottomSheetRef.close();
+        if (bottomSheetRef.nativeElement.open) {
+          bottomSheetRef.close();
+          return;
+        }
+        
         componentRef.destroy();
-        sub.unsubscribe();
         bottomSheetElement.remove();
       });
     });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N
- Docs have been added / updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
The value provided to `DialogRef.close(value)` will now properly be emitted by the `afterClosed` observable.
