### PR TITLE
fix(DialogService): fixed a bug where the `DialogConfig` token was not injecting if just `data` was provided

### DIFF
--- a/projects/forge-angular/src/lib/dialog/dialog-ref.ts
+++ b/projects/forge-angular/src/lib/dialog/dialog-ref.ts
@@ -28,4 +28,8 @@ export class DialogRef<TComponent = any, TResult = any> {
   public get nativeElement(): IDialogComponent {
     return this._elementRef.nativeElement;
   }
+
+  public get isClosed(): boolean {
+    return this._afterClosed.closed;
+  }
 }

--- a/projects/forge-angular/src/lib/dialog/dialog.service.ts
+++ b/projects/forge-angular/src/lib/dialog/dialog.service.ts
@@ -71,13 +71,18 @@ export class DialogService {
     // Contains tokens that will be provided to components through our custom dialog injector
     const providers: Provider[] = [];
 
+    // Since config and data can be provided separately, we should create a config with data if only data was provided
+    if (!config && data != null) {
+      config = { data };
+    }
+
     // If we got a config, we should provide it as an injection token
     if (config) {
       providers.push({ provide: DialogConfig, useValue: config });
     }
 
-    // If we got data, we should provide it as an injection token
-    if (data !== null && data !== undefined) {
+    // If we got data, we should also provide it as a injection token on its own
+    if (data != null) {
       providers.push({ provide: DIALOG_DATA, useValue: data });
     }
 
@@ -112,15 +117,11 @@ export class DialogService {
       const element = (componentRef.hostView as EmbeddedViewRef<any>).rootNodes[0] as HTMLElement;
       dialogElement.appendChild(element);
 
-      const sub = dialogRef.afterClosed.subscribe(() => {
-        componentRef.destroy();
-        sub.unsubscribe();
-      });
-
       dialogElement.addEventListener('forge-dialog-close', () => {
-        dialogRef.close();
+        if (!dialogRef.isClosed) {
+          dialogRef.close();
+        }
         componentRef.destroy();
-        sub.unsubscribe();
         dialogElement.remove();
       });
     });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N
- Docs have been added / updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
The `DialogConfig` token was not made available to the environment injector if the `config` parameter was not specified. This will now always be available if either the `config` or `data` parameters are provided.
