### PR TITLE
fix(DialogService): fixed a bug where the `componentInstance` was not being set to the dynamic Angular component instance

### DIFF
--- a/projects/forge-angular/src/lib/dialog/dialog.service.ts
+++ b/projects/forge-angular/src/lib/dialog/dialog.service.ts
@@ -112,6 +112,7 @@ export class DialogService {
       const parentInjector = injector ?? module?.injector ?? this._injector;
       const environmentInjector = createEnvironmentInjector(providers, parentInjector);
       const componentRef = createComponent(component, { environmentInjector });
+      dialogRef.componentInstance = componentRef.instance;
       this._appRef.attachView(componentRef.hostView);
 
       const element = (componentRef.hostView as EmbeddedViewRef<any>).rootNodes[0] as HTMLElement;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N
- Docs have been added / updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Ensures that the `DialogRef.componentInstance` is set when creating the dynamic Angular component instance.
