### PR TITLE
fix(PopoverDirective): fixed a bug where dynamically created `<forge-popover>` elements could not be accessed when a `<forge-dialog>` element is open

### DIFF
--- a/projects/forge-angular/src/lib/popover/popover.directive.ts
+++ b/projects/forge-angular/src/lib/popover/popover.directive.ts
@@ -43,7 +43,7 @@ export class PopoverDirective implements OnDestroy {
   }
 
   constructor(
-    private _elementRef: ElementRef,
+    private _elementRef: ElementRef<HTMLElement>,
     private _viewContainerRef: ViewContainerRef) {
     this._elementRef.nativeElement.addEventListener(POPOVER_CONSTANTS.events.TOGGLE, () => {
       window.requestAnimationFrame(() => this.close());
@@ -86,7 +86,14 @@ export class PopoverDirective implements OnDestroy {
       this._popoverElement.persistent = this.persistent;
     }
 
-    this._elementRef.nativeElement.getRootNode().body.appendChild(this._popoverElement);
+    let hostElement: Element | ShadowRoot | null = this._elementRef.nativeElement.closest(POPOVER_CONSTANTS.selectors.HOST);
+    if (!hostElement) {
+      const rootNode = this._elementRef.nativeElement.getRootNode();
+      const hostRootNode = rootNode instanceof ShadowRoot ? rootNode : (this._elementRef.nativeElement.ownerDocument ?? document).body;
+      hostElement = hostRootNode;
+    }
+
+    hostElement.appendChild(this._popoverElement);
     this._popoverElement.anchorElement = this._elementRef.nativeElement;
     this._popoverElement.open = true;
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N
- Docs have been added / updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Previously when opening a `<forge-popover>` via the `forgePopover` Angular directive from `<forge-dialog>`, the `<forge-popover>` itself could be interacted with due to the usage of native `<dialog>` within `<forge-dialog>` making the rest of the page `inert`.

Now the `forgePopover` directive will attempt to locate the host element via `closest(<selector>)` and fall back to the `<body>` if none are found. This ensures the `<forge-popover>` is properly added as a child of the `<forge-dialog>` so that it can be interacted with.