### PR TITLE
feat(dialog): add elementInjector option to config

### DIFF
--- a/projects/forge-angular/src/lib/dialog/dialog.service.ts
+++ b/projects/forge-angular/src/lib/dialog/dialog.service.ts
@@ -35,7 +35,6 @@ export class DialogService {
   constructor(
     private _appRef: ApplicationRef,
     private _injector: EnvironmentInjector,
-    private _elementInjector: Injector,
     private _ngZone: NgZone) {
     defineDialogComponent();
   }
@@ -113,8 +112,7 @@ export class DialogService {
     this._ngZone.run(() => {
       const parentInjector = injector ?? module?.injector ?? this._injector;
       const environmentInjector = createEnvironmentInjector(providers, parentInjector);
-      const localInjector = this._elementInjector === this._injector ? undefined: this._elementInjector;
-      const componentRef = createComponent(component, { environmentInjector, elementInjector: elementInjector ?? localInjector });
+      const componentRef = createComponent(component, { environmentInjector, elementInjector });
       dialogRef.componentInstance = componentRef.instance;
       this._appRef.attachView(componentRef.hostView);
 

--- a/projects/forge-angular/src/lib/dialog/dialog.service.ts
+++ b/projects/forge-angular/src/lib/dialog/dialog.service.ts
@@ -1,4 +1,4 @@
-import { ApplicationRef, DestroyRef, EmbeddedViewRef, EnvironmentInjector, Injectable, NgZone, Provider, createComponent, createEnvironmentInjector, inject } from '@angular/core';
+import { ApplicationRef, DestroyRef, EmbeddedViewRef, EnvironmentInjector, Injectable, Injector, NgZone, Provider, createComponent, createEnvironmentInjector, inject } from '@angular/core';
 import { Type, NgModuleRef } from '@angular/core';
 import { IDialogProperties, defineDialogComponent } from '@tylertech/forge';
 import { DIALOG_DATA, DialogConfig } from './dialog-config';
@@ -19,6 +19,7 @@ export interface IDialogServiceShowConfiguration<TModule = unknown> {
   data?: any;
   module?: NgModuleRef<TModule>;
   injector?: EnvironmentInjector;
+  elementInjector?: Injector;
 }
 
 /**
@@ -34,6 +35,7 @@ export class DialogService {
   constructor(
     private _appRef: ApplicationRef,
     private _injector: EnvironmentInjector,
+    private _elementInjector: Injector,
     private _ngZone: NgZone) {
     defineDialogComponent();
   }
@@ -66,7 +68,7 @@ export class DialogService {
 
   private _showDialog<TComponent, TModule>(
     component: Type<TComponent>,
-    { config, data, injector, module, options }: IDialogServiceShowConfiguration<TModule>
+    { config, data, injector, elementInjector, module, options }: IDialogServiceShowConfiguration<TModule>
   ): DialogRef<TComponent> {
     // Contains tokens that will be provided to components through our custom dialog injector
     const providers: Provider[] = [];
@@ -111,7 +113,8 @@ export class DialogService {
     this._ngZone.run(() => {
       const parentInjector = injector ?? module?.injector ?? this._injector;
       const environmentInjector = createEnvironmentInjector(providers, parentInjector);
-      const componentRef = createComponent(component, { environmentInjector });
+      const localInjector = this._elementInjector === this._injector ? undefined: this._elementInjector;
+      const componentRef = createComponent(component, { environmentInjector, elementInjector: elementInjector ?? localInjector });
       dialogRef.componentInstance = componentRef.instance;
       this._appRef.attachView(componentRef.hostView);
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: n//a
- Docs have been added / updated: n/a
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? n/a

## Describe the new behavior?
As part of the Forge 3.0 migration, the DialogService was switched over to rely entirely on `EnvironmentInjector`, which limited some ways dependencies could be provided to the dynamically-created component.  By allowing an ElementInjector to be provided, `createComponent` can leverage the local hierarchy directly without having to explicitly copy over all relevant providers, which may not even be known since they could be specified at a higher level.

## Additional information
I had initially considered injected the local `Injector` instance, and defaulting to use that if it differed from the local `EnvironmentInjector`, implying the service was being provided at the component level.  We had done this as a workaround in a few places, but it would interfere with the `closeAllDialogs` functionality, and there are better alternatives, provided this option is added.  A component can provide it's injector directly, or a wrapper service could be provided at the component-level and do the same.