### PR TITLE
feat: bump peer dep range to include ng 20

### DIFF
--- a/projects/forge-angular/package.json
+++ b/projects/forge-angular/package.json
@@ -6,8 +6,8 @@
   "author": "Tyler Technologies, Inc.",
   "license": "Apache-2.0",
   "peerDependencies": {
-    "@angular/common": ">=18.0.0 < 20.0.0",
-    "@angular/core": ">=18.0.0 < 20.0.0",
+    "@angular/common": ">=18.0.0 < 21.0.0",
+    "@angular/core": ">=18.0.0 < 21.0.0",
     "@tylertech/forge": "^3.8.0"
   },
   "dependencies": {


### PR DESCRIPTION
This is just to allow installing this package in apps using Angular 20 to avoid peer dep warnings/overrides. The API is compatible with Angular 18+, and we'll be releasing an Angular 20+ specific package in 6.x soon with some usage of new Angular APIs. This update just spans the gap until we're able to release that new package with the new features.