### PR TITLE
fix: add the root lib module back and re-export it

### DIFF
--- a/projects/forge-angular/src/lib/forge.module.ts
+++ b/projects/forge-angular/src/lib/forge.module.ts
@@ -1,0 +1,178 @@
+import { NgModule } from '@angular/core';
+
+import { ForgeAccordionModule } from './accordion';
+import { ForgeAppBarModule } from './app-bar';
+import { ForgeAppBarHelpButtonModule } from './app-bar-help-button';
+import { ForgeAppBarMenuButtonModule } from './app-bar-menu-button';
+import { ForgeAppBarNotificationButtonModule } from './app-bar-notification-button';
+import { ForgeAppBarProfileButtonModule } from './app-bar-profile-button';
+import { ForgeAppBarSearchModule } from './app-bar-search';
+import { ForgeAutocompleteModule } from './autocomplete';
+import { ForgeAvatarModule } from './avatar';
+import { ForgeBackdropModule } from './backdrop';
+import { ForgeBadgeModule } from './badge';
+import { ForgeBannerModule } from './banner';
+import { ForgeBottomSheetModule } from './bottom-sheet';
+import { ForgeButtonModule } from './button';
+import { ForgeButtonAreaModule } from './button-area';
+import { ForgeButtonToggleModule } from './button-toggle';
+import { ForgeButtonToggleGroupModule } from './button-toggle-group';
+import { ForgeCalendarModule } from './calendar';
+import { ForgeCardModule } from './card';
+import { ForgeCheckboxModule } from './checkbox';
+import { ForgeChipModule } from './chip';
+import { ForgeChipFieldModule } from './chip-field';
+import { ForgeChipSetModule } from './chip-set';
+import { ForgeCircularProgressModule } from './circular-progress';
+import { ForgeColorPickerModule } from './color-picker';
+import { ForgeDatePickerModule } from './date-picker';
+import { ForgeDateRangePickerModule } from './date-range-picker';
+import { ForgeDeprecatedButtonModule } from './deprecated-button';
+import { ForgeDeprecatedIconButtonModule } from './deprecated-icon-button';
+import { ForgeDialogModule } from './dialog';
+import { ForgeDividerModule } from './divider';
+import { ForgeDrawerModule } from './drawer';
+import { ForgeExpansionPanelModule } from './expansion-panel';
+import { ForgeFloatingActionButtonModule } from './fab';
+import { ForgeFieldModule } from './field';
+import { ForgeFilePickerModule } from './file-picker';
+import { ForgeFocusIndicatorModule } from './focus-indicator';
+import { ForgeIconModule } from './icon';
+import { ForgeIconButtonModule } from './icon-button';
+import { ForgeInlineMessageModule } from './inline-message';
+import { ForgeKeyModule } from './key/key.module';
+import { ForgeKeyboardShortcutModule } from './keyboard-shortcut';
+import { ForgeLabelModule } from './label';
+import { ForgeLabelValueModule } from './label-value';
+import { ForgeLinearProgressModule } from './linear-progress';
+import { ForgeListModule } from './list';
+import { ForgeListItemModule } from './list-item';
+import { ForgeMenuModule } from './menu';
+import { ForgeMeterGroupModule } from './meter-group/meter-group.module';
+import { ForgeMiniDrawerModule } from './mini-drawer';
+import { ForgeModalDrawerModule } from './modal-drawer';
+import { ForgeOpenIconModule } from './open-icon';
+import { ForgeOptionModule } from './option';
+import { ForgeOptionGroupModule } from './option-group';
+import { ForgeOverlayModule } from './overlay';
+import { ForgePageStateModule } from './page-state';
+import { ForgePaginatorModule } from './paginator';
+import { ForgePopoverModule } from './popover';
+import { ForgeProfileCardModule } from './profile-card';
+import { ForgeRadioModule } from './radio';
+import { ForgeRadioGroupModule } from './radio-group';
+import { ForgeScaffoldModule } from './scaffold';
+import { ForgeSelectModule } from './select';
+import { ForgeSelectDropdownModule } from './select-dropdown';
+import { ForgeSkeletonModule } from './skeleton';
+import { ForgeSkipLinkModule } from './skip-link/skip-link.module';
+import { ForgeSliderModule } from './slider';
+import { ForgeSplitButtonModule } from './split-button';
+import { ForgeSplitViewModule } from './split-view';
+import { ForgeSplitViewPanelModule } from './split-view-panel';
+import { ForgeStackModule } from './stack';
+import { ForgeStateLayerModule } from './state-layer';
+import { ForgeStepModule } from './step';
+import { ForgeStepperModule } from './stepper';
+import { ForgeSwitchModule } from './switch';
+import { ForgeTabModule } from './tab';
+import { ForgeTabBarModule } from './tab-bar';
+import { ForgeTableModule } from './table';
+import { ForgeTextFieldModule } from './text-field';
+import { ForgeTimePickerModule } from './time-picker';
+import { ForgeToastModule } from './toast';
+import { ForgeToolbarModule } from './toolbar';
+import { ForgeTooltipModule } from './tooltip';
+import { ForgeViewModule } from './view';
+import { ForgeViewSwitcherModule } from './view-switcher';
+
+@NgModule({
+  exports: [
+    ForgeAccordionModule,
+    ForgeAppBarModule,
+    ForgeAppBarHelpButtonModule,
+    ForgeAppBarMenuButtonModule,
+    ForgeAppBarNotificationButtonModule,
+    ForgeAppBarProfileButtonModule,
+    ForgeAppBarSearchModule,
+    ForgeAutocompleteModule,
+    ForgeAvatarModule,
+    ForgeBackdropModule,
+    ForgeBadgeModule,
+    ForgeBannerModule,
+    ForgeBottomSheetModule,
+    ForgeButtonModule,
+    ForgeButtonAreaModule,
+    ForgeButtonToggleModule,
+    ForgeButtonToggleGroupModule,
+    ForgeCalendarModule,
+    ForgeCardModule,
+    ForgeCheckboxModule,
+    ForgeChipModule,
+    ForgeChipFieldModule,
+    ForgeChipSetModule,
+    ForgeCircularProgressModule,
+    ForgeColorPickerModule,
+    ForgeDatePickerModule,
+    ForgeDateRangePickerModule,
+    ForgeDeprecatedButtonModule,
+    ForgeDeprecatedIconButtonModule,
+    ForgeDialogModule,
+    ForgeDividerModule,
+    ForgeDrawerModule,
+    ForgeExpansionPanelModule,
+    ForgeFloatingActionButtonModule,
+    ForgeFieldModule,
+    ForgeFilePickerModule,
+    ForgeFocusIndicatorModule,
+    ForgeIconModule,
+    ForgeIconButtonModule,
+    ForgeInlineMessageModule,
+    ForgeKeyModule,
+    ForgeKeyboardShortcutModule,
+    ForgeLabelModule,
+    ForgeLabelValueModule,
+    ForgeLinearProgressModule,
+    ForgeListModule,
+    ForgeListItemModule,
+    ForgeMenuModule,
+    ForgeMeterGroupModule,
+    ForgeMiniDrawerModule,
+    ForgeModalDrawerModule,
+    ForgeOpenIconModule,
+    ForgeOptionModule,
+    ForgeOptionGroupModule,
+    ForgeOverlayModule,
+    ForgePageStateModule,
+    ForgePaginatorModule,
+    ForgePopoverModule,
+    ForgeProfileCardModule,
+    ForgeRadioModule,
+    ForgeRadioGroupModule,
+    ForgeScaffoldModule,
+    ForgeSelectModule,
+    ForgeSelectDropdownModule,
+    ForgeSkeletonModule,
+    ForgeSkipLinkModule,
+    ForgeSliderModule,
+    ForgeSplitButtonModule,
+    ForgeSplitViewModule,
+    ForgeSplitViewPanelModule,
+    ForgeStackModule,
+    ForgeStateLayerModule,
+    ForgeStepModule,
+    ForgeStepperModule,
+    ForgeSwitchModule,
+    ForgeTabModule,
+    ForgeTabBarModule,
+    ForgeTableModule,
+    ForgeTextFieldModule,
+    ForgeTimePickerModule,
+    ForgeToastModule,
+    ForgeToolbarModule,
+    ForgeTooltipModule,
+    ForgeViewModule,
+    ForgeViewSwitcherModule
+  ]
+})
+export class ForgeModule {}

--- a/projects/forge-angular/src/public-api.ts
+++ b/projects/forge-angular/src/public-api.ts
@@ -90,4 +90,4 @@ export * from './lib/tooltip';
 export * from './lib/view';
 export * from './lib/view-switcher';
 
-
+export * from './lib/forge.module';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: [N]
- Docs have been added / updated: [N]
- Does this PR introduce a breaking change? [N]
- I have linked any related GitHub issues to be closed when this PR is merged? n/a

## Describe the new behavior?
The lib's root forge.module was somehow deleted in my ng19-20 update PR. This PR adds it back in.

~Though maybe we should chat to see if it's needed. It does somewhat enable the poor practice of importing all forge modules... which is handy for testing and unofficial tools. Not great for applications in production.~

Update: we'll go ahead and bring it back for backwards compatibility. There are docs that tell folks not to use it in prod.
