### PR TITLE
feat(dialog): add directive options

### DIFF
--- a/projects/forge-angular/src/lib/dialog/dialog.service.ts
+++ b/projects/forge-angular/src/lib/dialog/dialog.service.ts
@@ -1,4 +1,4 @@
-import { ApplicationRef, DestroyRef, EmbeddedViewRef, EnvironmentInjector, Injectable, Injector, NgZone, Provider, createComponent, createEnvironmentInjector, inject } from '@angular/core';
+import { ApplicationRef, Binding, DestroyRef, EmbeddedViewRef, EnvironmentInjector, Injectable, Injector, NgZone, Provider, createComponent, createEnvironmentInjector, inject } from '@angular/core';
 import { Type, NgModuleRef } from '@angular/core';
 import { IDialogProperties, defineDialogComponent } from '@tylertech/forge';
 import { DIALOG_DATA, DialogConfig } from './dialog-config';
@@ -20,6 +20,8 @@ export interface IDialogServiceShowConfiguration<TModule = unknown> {
   module?: NgModuleRef<TModule>;
   injector?: EnvironmentInjector;
   elementInjector?: Injector;
+  directives?: (Type<unknown> | {type: Type<unknown>; bindings: Binding[]})[];
+  bindings?: Binding[];
 }
 
 /**
@@ -68,7 +70,7 @@ export class DialogService {
 
   private _showDialog<TComponent, TModule>(
     component: Type<TComponent>,
-    { config, data, injector, elementInjector, module, options }: IDialogServiceShowConfiguration<TModule>
+    { config, data, injector, elementInjector, module, options, directives, bindings }: IDialogServiceShowConfiguration<TModule>
   ): DialogRef<TComponent> {
     // Contains tokens that will be provided to components through our custom dialog injector
     const providers: Provider[] = [];
@@ -113,7 +115,7 @@ export class DialogService {
     this._ngZone.run(() => {
       const parentInjector = injector ?? module?.injector ?? this._injector;
       const environmentInjector = createEnvironmentInjector(providers, parentInjector);
-      const componentRef = createComponent(component, { environmentInjector, elementInjector });
+      const componentRef = createComponent(component, { environmentInjector, elementInjector, directives, bindings });
       dialogRef.componentRef = componentRef;
       dialogRef.componentInstance = componentRef.instance;
       this._appRef.attachView(componentRef.hostView);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N
- Docs have been added / updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? n/a

## Describe the new behavior?
Adds options to `IDialogServiceShowConfiguration` corresponding with latest [createComponent](https://angular.dev/api/core/createComponent) api. This api is identical between Angular 20 and 21, so this add is compatible with this lib's Angular peer dep range.

## Additional information
The same add could also be made for other dynamic component services in the lib like `PopoverService` but I figured these might get the same `show` -> `open` makeover `DialogService` did and could have these options added then.